### PR TITLE
Add import issues from Notion functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,33 @@ $ docker run public.registry.jetbrains.space/p/space/containers/space-issues-imp
 
 `In progress`
 
+## From Notion
+
+```
+$ docker run public.registry.jetbrains.space/p/space/containers/space-issues-import:latest 
+        --importSource Notion \
+        --notionToken SECRET \
+        --notionDatabaseId SECRET \
+        --notionAssigneeProperty name::Assignee \
+        --notionAssigneePropertyMappingType name \
+        --notionStatusProperty name::Status \
+        --notionStatusPropertyMappingType name \
+        --notionTagProperty name::Project \
+        --notionTagPropertyMappingType name \
+        --tagPropertyMappingType name \
+        --spaceServer "https://<domain>.jetbrains.space" \
+        --spaceToken SECRET \
+        --spaceProject key::ABC \
+        --spaceBoard name::Tasks \
+        --replaceMissingStatus \
+        --replaceMissingAssignee \
+        --assignee "John Doe::john.doe" \
+        --status "TODO::🔍 TODO" \
+        --status "Done::✅ Done" \
+        --tag "📱 Android::🤖 Android" \
+        --tag "🍏 iOS::🍏 iOS"
+```
+
 # Arguments
 
 ```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ $ docker run public.registry.jetbrains.space/p/space/containers/space-issues-imp
 ```
 $ docker run public.registry.jetbrains.space/p/space/containers/space-issues-import:latest 
         --importSource Notion \
+        --notionQuery "{\"filter\":{},\"sorts\":{},\"start_cursor\":\"\",\"page_size\":100}" \
         --notionToken SECRET \
         --notionDatabaseId SECRET \
         --notionAssigneeProperty name::Assignee \
@@ -61,11 +62,22 @@ $ docker run public.registry.jetbrains.space/p/space/containers/space-issues-imp
 usage: [-h] [--jiraServer JIRASERVER] [--jiraQuery JIRAQUERY]
        [--jiraUser JIRAUSER] [--jiraPassword JIRAPASSWORD]
        [--youtrackServer YOUTRACKSERVER] [--youtrackQuery YOUTRACKQUERY]
-       [--youtrackToken YOUTRACKTOKEN] --spaceServer SPACESERVER
+       [--youtrackToken YOUTRACKTOKEN] [--notionDatabaseId NOTIONDATABASEID]
+       [--notionToken NOTIONTOKEN]
+       [--notionAssigneeProperty NOTIONASSIGNEEPROPERTY]
+       [--notionStatusProperty NOTIONSTATUSPROPERTY]
+       [--notionTagProperty NOTIONTAGPROPERTY]
+       [--notionAssigneePropertyMappingType NOTIONASSIGNEEPROPERTYMAPPINGTYPE]
+       [--notionStatusPropertyMappingType NOTIONSTATUSPROPERTYMAPPINGTYPE]
+       [--notionTagPropertyMappingType NOTIONTAGPROPERTYMAPPINGTYPE]
+       [--notionQuery NOTIONQUERY] --spaceServer SPACESERVER
        --spaceToken SPACETOKEN --spaceProject SPACEPROJECT
        [--importSource IMPORTSOURCE] [--dryRun] [--updateExistingIssues]
        [--replaceMissingStatus] [--replaceMissingAssignee] [-a ASSIGNEE]...
-       [-s STATUS]... [--batchSize BATCHSIZE]
+       [-s STATUS]... [--batchSize BATCHSIZE] [--debug]
+       [--spaceBoard SPACEBOARD] [-t TAG]...
+       [--tagPropertyMappingType TAGPROPERTYMAPPINGTYPE]
+
 
 required arguments:
   --spaceServer SPACESERVER         The URL of the Space instance that you

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.4.21'
+    id 'org.jetbrains.kotlin.jvm' version '1.5.31'
 }
 
 group 'com.jetbrains.space-issues-import'
@@ -16,11 +16,12 @@ repositories {
     maven { url "https://packages.atlassian.com/maven/repository/public" }
 }
 
-def space_sdk_version = '80470-beta'
+def space_sdk_version = '85203-beta'
 def youtrack_rest_client_version = '0.2.19'
 def jira_rest_client_version = '5.2.2'
+def notion_rest_client_version = '0.0.5'
 
-def kotlinx_coroutines_version = '1.3.8'
+def kotlinx_coroutines_version = '1.5.1'
 def ktor_client_version = '1.6.3'
 def kotlin_argparser_version = '2.0.7'
 
@@ -43,6 +44,9 @@ dependencies {
     // Jira
     implementation "com.atlassian.jira:jira-rest-java-client-core:$jira_rest_client_version"
     implementation 'io.atlassian.fugue:fugue:4.7.2'
+
+    // Notion
+    implementation "com.petersamokhin.notionsdk:notionsdk:$notion_rest_client_version"
 
     testCompile group: 'junit', name: 'junit', version: '4.13'
 }

--- a/src/main/kotlin/CommandLineArgs.kt
+++ b/src/main/kotlin/CommandLineArgs.kt
@@ -1,11 +1,16 @@
 package com.jetbrains.space.import
 
+import com.jetbrains.space.import.common.ExternalProjectProperty
+import com.jetbrains.space.import.common.ProjectPropertyType
+import com.jetbrains.space.import.common.ImportSource
+import com.jetbrains.space.import.space.SpaceBoardCustomIdentifier
 import com.xenomachina.argparser.ArgParser
 import com.xenomachina.argparser.SystemExitException
 import com.xenomachina.argparser.default
 import space.jetbrains.api.runtime.types.ImportExistsPolicy
 import space.jetbrains.api.runtime.types.ImportMissingPolicy
 import space.jetbrains.api.runtime.types.ProjectIdentifier
+import java.util.*
 
 data class CommandLineArgs(private val parser: ArgParser) {
     private val mappingSeparator = "::"
@@ -47,7 +52,99 @@ data class CommandLineArgs(private val parser: ArgParser) {
     val youtrackToken by parser.storing(
         "--youtrackToken",
         help = "An optional permanent token that grants access to the YouTrack server for a specific user account. " +
-                "If not specified, issue data is retrieved according to the access rights that are available to the guest account."
+            "If not specified, issue data is retrieved according to the access rights that are available to the guest account."
+    ).default(null)
+
+    // Notion
+
+    val notionDatabaseId by parser.storing(
+        "--notionDatabaseId",
+        help = "The ID of the Notion database that you want to import issues from."
+    ).default(null)
+
+    val notionToken by parser.storing(
+        "--notionToken",
+        help = "A mandatory token to access the Notion API."
+    ).default(null)
+
+    val notionAssigneeProperty by parser.storing(
+        "--notionAssigneeProperty",
+        help = "The name or ID of a property in Notion which will be mapped to the Space issue assignee. For example, name::Title or id:uuid-uuid-uuid",
+        transform = {
+            val (identifierType, identifier) = parseMapping(this)
+            when (identifierType.lowercase(Locale.getDefault())) {
+                "name" -> ExternalProjectProperty.Name(identifier)
+                "id" -> ExternalProjectProperty.Id(identifier)
+                else -> throw SystemExitException("only name::value or id::value are allowed for --notionAssigneeProperty as identifier",
+                    2)
+            }
+        }
+    ).default(null)
+
+    val notionStatusProperty by parser.storing(
+        "--notionStatusProperty",
+        help = "The name or ID of a property in Notion which will be mapped to the Space issue status. For example, name::Title or id:uuid-uuid-uuid",
+        transform = {
+            val (identifierType, identifier) = parseMapping(this)
+            when (identifierType.lowercase(Locale.getDefault())) {
+                "name" -> ExternalProjectProperty.Name(identifier)
+                "id" -> ExternalProjectProperty.Id(identifier)
+                else -> throw SystemExitException("only name::value or id::value are allowed for --notionStatusProperty as identifier",
+                    2)
+            }
+        }
+    ).default(null)
+
+    val notionTagProperty by parser.storing(
+        "--notionTagProperty",
+        help = "The name or ID of a property in Notion which will be mapped to the Space issue tag. For example, name::Title or id:uuid-uuid-uuid",
+        transform = {
+            val (identifierType, identifier) = parseMapping(this)
+            when (identifierType.lowercase(Locale.getDefault())) {
+                "name" -> ExternalProjectProperty.Name(identifier)
+                "id" -> ExternalProjectProperty.Id(identifier)
+                else -> throw SystemExitException("only name::value or id::value are allowed for --notionStatusProperty as identifier",
+                    2)
+            }
+        }
+    ).default(null)
+
+    val notionAssigneePropertyMappingType by parser.storing(
+        "--notionAssigneePropertyMappingType",
+        help = "id, name, or email. Default: name. For --assignee command, what to map on the Notion side, " +
+            "e.g. '--assignee uuid-uuid::john.doe' for 'id' vs '--assignee John Doe::john.doe' for 'name'. " +
+            "Please note that email will be used in case if the property is person (including created & edited by); " +
+            "id will be used in case of a person, select or multiselect. " +
+            "Plain value (name) will be used otherwise (for email, phone number, text, title, etc.)",
+        transform = {
+            ProjectPropertyType.values().find { it.name.equals(this, ignoreCase = true) }
+                ?: ProjectPropertyType.Name
+        }
+    ).default(ProjectPropertyType.Name)
+
+    val notionStatusPropertyMappingType by parser.storing(
+        "--notionStatusPropertyMappingType",
+        help = "id or name, default: name. For --status command, what to map on the Notion side, " +
+            "e.g. '--tag uuid-uuid::To Do' for 'id' vs '--tag To Do::To Do' for 'name'.",
+        transform = {
+            ProjectPropertyType.values().find { it.name.equals(this, ignoreCase = true) }
+                ?: ProjectPropertyType.Name
+        }
+    ).default(ProjectPropertyType.Name)
+
+    val notionTagPropertyMappingType by parser.storing(
+        "--notionTagPropertyMappingType",
+        help = "id or name, default: name. For --tag command, what to map on the Notion side, " +
+            "e.g. '--tag uuid-uuid::Android' for 'id' vs '--tag Android::Android' for 'name'.",
+        transform = {
+            ProjectPropertyType.values().find { it.name.equals(this, ignoreCase = true) }
+                ?: ProjectPropertyType.Name
+        }
+    ).default(ProjectPropertyType.Name)
+
+    val notionQuery by parser.storing(
+        "--notionQuery",
+        help = "JSON string which will be used as the request body to databases/:id/query. By default, all the cards from the board are exported."
     ).default(null)
 
     // Space
@@ -63,58 +160,59 @@ data class CommandLineArgs(private val parser: ArgParser) {
     )
 
     val spaceProject by parser.storing(
-            "--spaceProject",
-            help = "The key or ID of a project in Space into which you want to import issues. For example, key${mappingSeparator}ABC or id${mappingSeparator}42.",
-            transform = {
-                val (identifierType, identifier) = parseMapping(this)
-                when (identifierType.toLowerCase()) {
-                    "key" -> ProjectIdentifier.Key(identifier)
-                    "id" -> ProjectIdentifier.Key(identifier)
-                    else -> throw SystemExitException("only key::value or id::value are allowed for --spaceProject as identifier", 2)
-                }
+        "--spaceProject",
+        help = "The key or ID of a project in Space into which you want to import issues. For example, key${mappingSeparator}ABC or id${mappingSeparator}42.",
+        transform = {
+            val (identifierType, identifier) = parseMapping(this)
+            when (identifierType.lowercase(Locale.getDefault())) {
+                "key" -> ProjectIdentifier.Key(identifier)
+                "id" -> ProjectIdentifier.Key(identifier)
+                else -> throw SystemExitException("only key::value or id::value are allowed for --spaceProject as identifier", 2)
             }
+        }
     )
 
     // Space /import API arguments
 
     val importSource by parser.storing(
         "--importSource",
-        help = "The name of the import source. Default: External."
-    ).default("External")
+        help = "The name of the import source. Default: External.",
+        transform = { ImportSource.values().find { it.name.equals(this, ignoreCase = true) } ?: ImportSource.External }
+    ).default(ImportSource.External)
 
     val dryRun by parser.flagging(
-            "--dryRun",
-            help = "Runs the import script without actually creating issues."
+        "--dryRun",
+        help = "Runs the import script without actually creating issues."
     )
 
     val onExistsPolicy by parser.mapping(
-            "--updateExistingIssues" to ImportExistsPolicy.Update,
-            "--skipExistingIssues" to ImportExistsPolicy.Skip,
-            help = "Tells Space how to process issues when their external IDs matches previously imported issues in Space. Default: skipExistingIssues."
+        "--updateExistingIssues" to ImportExistsPolicy.Update,
+        "--skipExistingIssues" to ImportExistsPolicy.Skip,
+        help = "Tells Space how to process issues when their external IDs matches previously imported issues in Space. Default: skipExistingIssues."
     ).default(ImportExistsPolicy.Skip)
 
     val statusMissingPolicy by parser.mapping(
-            "--replaceMissingStatus" to ImportMissingPolicy.ReplaceWithDefault,
-            "--skipMissingStatus" to ImportMissingPolicy.Skip,
-            help = "Tells Space how to handle issues when the value for the status field does not exist. `replaceMissingStatus` sets it to the first unresolved status. Default: `skipMissingStatus`."
+        "--replaceMissingStatus" to ImportMissingPolicy.ReplaceWithDefault,
+        "--skipMissingStatus" to ImportMissingPolicy.Skip,
+        help = "Tells Space how to handle issues when the value for the status field does not exist. `replaceMissingStatus` sets it to the first unresolved status. Default: `skipMissingStatus`."
     ).default(ImportMissingPolicy.Skip)
 
     val assigneeMissingPolicy by parser.mapping(
-            "--replaceMissingAssignee" to ImportMissingPolicy.ReplaceWithDefault,
-            "--skipMissingAssignee" to ImportMissingPolicy.Skip,
-            help = "Tells Space how to handle issues when the value for the assignee field does not exist. `replaceMissingAssignee` sets it to `unassigned`. Default: `skipMissingAssignee`."
+        "--replaceMissingAssignee" to ImportMissingPolicy.ReplaceWithDefault,
+        "--skipMissingAssignee" to ImportMissingPolicy.Skip,
+        help = "Tells Space how to handle issues when the value for the assignee field does not exist. `replaceMissingAssignee` sets it to `unassigned`. Default: `skipMissingAssignee`."
     ).default(ImportMissingPolicy.Skip)
 
     // add-ons
 
     val assigneeMapping by parser.adding(
-            "-a", "--assignee",
-            help = "Maps the assignee in the external system to a member profile in Space. For example, leonid.tolstoy${mappingSeparator}leo.tolstoy.",
-            transform = { parseMapping(this) }
+        "-a", "--assignee",
+        help = "Maps the assignee in the external system to a member profile in Space. For example, leonid.tolstoy${mappingSeparator}leo.tolstoy.",
+        transform = { parseMapping(this) }
     ).default(emptyList())
 
     val statusMapping by parser.adding(
-            "-s", "--status",
+        "-s", "--status",
         help = "Maps an issue status in the external system to an issue status in Space. For example, in-progress${mappingSeparator}In Progress.",
         transform = { parseMapping(this) }
     ).default(emptyList())
@@ -129,6 +227,38 @@ data class CommandLineArgs(private val parser: ArgParser) {
         "--debug",
         help = "Runs the import script in debug mode."
     )
+
+    val spaceBoard by parser.storing(
+        "--spaceBoard",
+        help = "The name or ID of a project in Space into which you want to import issues. For example, name::Tasks or id:DRrHX45Jsxl",
+        transform = {
+            val (identifierType, identifier) = parseMapping(this)
+            when (identifierType.lowercase(Locale.getDefault())) {
+                "name" -> SpaceBoardCustomIdentifier.Name(identifier)
+                "id" -> SpaceBoardCustomIdentifier.Id(identifier)
+                else -> throw SystemExitException("only name::value or id::value are allowed for --spaceBoard as identifier", 2)
+            }
+        }
+    ).default(null)
+
+    val tagMapping by parser.adding(
+        "-t", "--tag",
+        help = "[supported only for Notion] Maps the tag in the external system to a tag in Space. " +
+            "For example, external-tag${mappingSeparator}space-tag-id. " +
+            "Please remember to specify the tag property for the external system.",
+        transform = { parseMapping(this) }
+    ).default(emptyList())
+
+    val tagPropertyMappingType by parser.storing(
+        "--tagPropertyMappingType",
+        help = "id or name, default: name. Please add 'View project data' permission to your Space integration if you use 'name'. " +
+            "For --tag command, what to map on the Space side, " +
+            "e.g. '--tag Android::space-tag-id' for 'id' vs '--tag Android::Android' for 'name'.",
+        transform = {
+            ProjectPropertyType.values().find { it.name.equals(this, ignoreCase = true) }
+                ?: ProjectPropertyType.Name
+        }
+    ).default(ProjectPropertyType.Name)
 
     private fun parseMapping(arg: String, separator: String = mappingSeparator): Pair<String, String> {
         val mapping = arg.split(separator)

--- a/src/main/kotlin/common/ExternalProjectProperty.kt
+++ b/src/main/kotlin/common/ExternalProjectProperty.kt
@@ -1,0 +1,10 @@
+package com.jetbrains.space.import.common
+
+sealed interface ExternalProjectProperty {
+    class Id(val id: String) : ExternalProjectProperty
+    class Name(val name: String) : ExternalProjectProperty
+}
+
+enum class ProjectPropertyType {
+    Id, Name, Email
+}

--- a/src/main/kotlin/common/ImportSource.kt
+++ b/src/main/kotlin/common/ImportSource.kt
@@ -1,0 +1,5 @@
+package com.jetbrains.space.import.common
+
+enum class ImportSource {
+    YouTrack, Jira, Notion, External
+}

--- a/src/main/kotlin/common/IssuesLoader.kt
+++ b/src/main/kotlin/common/IssuesLoader.kt
@@ -3,10 +3,33 @@ package com.jetbrains.space.import.common
 import space.jetbrains.api.runtime.types.ExternalIssue
 
 interface IssuesLoader {
-    suspend fun load(query: String): IssuesLoadResult
+    suspend fun load(params: Params): IssuesLoadResult
+
+    sealed interface Params {
+        val query: String
+
+        class Notion(
+            override val query: String,
+            val databaseId: String,
+            val assigneeProperty: ExternalProjectProperty,
+            val assigneePropertyMappingType: ProjectPropertyType,
+            val statusProperty: ExternalProjectProperty,
+            val statusPropertyMappingType: ProjectPropertyType,
+            val tagProperty: ExternalProjectProperty,
+            val tagPropertyMappingType: ProjectPropertyType,
+        ) : Params
+
+        class YouTrack(
+            override val query: String,
+        ) : Params
+
+        class Jira(
+            override val query: String,
+        ) : Params
+    }
 }
 
-sealed class IssuesLoadResult {
-    data class Failed(val message: String) : IssuesLoadResult()
-    data class Success(val issues: List<ExternalIssue>) : IssuesLoadResult()
+sealed interface IssuesLoadResult {
+    data class Failed(val message: String) : IssuesLoadResult
+    data class Success(val issues: List<ExternalIssue>, val tags: Map<String, Set<String>>) : IssuesLoadResult
 }

--- a/src/main/kotlin/jira/JiraIssuesLoader.kt
+++ b/src/main/kotlin/jira/JiraIssuesLoader.kt
@@ -31,9 +31,9 @@ private class JiraIssuesLoader(private val jiraUrl: String, username: String?, p
         client = factory.createWithAuthenticationHandler(URI.create(jiraUrl), authHandler)
     }
 
-    override suspend fun load(query: String): IssuesLoadResult {
+    override suspend fun load(params: IssuesLoader.Params): IssuesLoadResult {
         return try {
-            migrate(query)
+            migrate(params.query)
         } catch (e: Exception) {
             LOG.error("Error whilst migrating issues", e)
             IssuesLoadResult.Failed(e.message ?: "Unknown exception")
@@ -68,7 +68,7 @@ private class JiraIssuesLoader(private val jiraUrl: String, username: String?, p
                 }
         } while (current < total)
 
-        return IssuesLoadResult.Success(allIssues.toList())
+        return IssuesLoadResult.Success(allIssues.toList(), emptyMap())
     }
 
     companion object {

--- a/src/main/kotlin/notion/NotionIssuesLoader.kt
+++ b/src/main/kotlin/notion/NotionIssuesLoader.kt
@@ -1,0 +1,175 @@
+package com.jetbrains.space.import.notion
+
+import com.jetbrains.space.import.common.ExternalProjectProperty
+import com.jetbrains.space.import.common.ProjectPropertyType
+import com.jetbrains.space.import.common.IssuesLoadResult
+import com.jetbrains.space.import.common.IssuesLoader
+import com.petersamokhin.notionsdk.Notion
+import com.petersamokhin.notionsdk.data.model.result.*
+import com.petersamokhin.notionsdk.markdown.NotionMarkdownExporter
+import io.ktor.client.*
+import io.ktor.client.engine.apache.*
+import space.jetbrains.api.runtime.types.ExternalIssue
+
+object NotionIssuesLoaderFactory {
+    fun create(token: String): IssuesLoader =
+        NotionIssuesLoader(token)
+}
+
+private class NotionIssuesLoader(token: String) : IssuesLoader {
+    private val notion = Notion.fromToken(token, httpClient = createHttpClient())
+    private val markdownExporter = NotionMarkdownExporter.create()
+
+    override suspend fun load(params: IssuesLoader.Params): IssuesLoadResult {
+        if (params !is IssuesLoader.Params.Notion)
+            return IssuesLoadResult.Failed("wrong params passed to Notion issues loader")
+
+        val notionCards = getAllNotionCards(databaseId = params.databaseId, query = params.query)
+
+        return IssuesLoadResult.Success(
+            issues = notionCards.map { card ->
+                ExternalIssue(
+                    summary = card.getTitle()
+                        ?: return IssuesLoadResult.Failed("No property found in Notion database for title"),
+                    description = card.getDescriptionAsMarkdown(),
+                    status = card.findProperty(params.statusProperty)?.value?.getTextValue(params.statusPropertyMappingType)
+                        .orEmpty(),
+                    assignee = card.findProperty(params.assigneeProperty)?.value?.getTextValue(params.assigneePropertyMappingType),
+                    externalId = card.id,
+                    externalName = "Notion",
+                    externalUrl = "https://notion.so/${card.id.replace("-", "")}",
+                )
+            },
+            tags = notionCards.associate { card ->
+                val tags: Set<String> = when (val property = card.findProperty(params.tagProperty)?.value) {
+                    is NotionDatabaseProperty.Title -> when (params.tagPropertyMappingType) {
+                        ProjectPropertyType.Id -> setOf(property.id)
+                        ProjectPropertyType.Name -> setOf(property.text)
+                        ProjectPropertyType.Email -> null
+                    }
+                    is NotionDatabaseProperty.Text -> when (params.tagPropertyMappingType) {
+                        ProjectPropertyType.Id -> setOf(property.id)
+                        ProjectPropertyType.Name -> setOf(property.text)
+                        ProjectPropertyType.Email -> null
+                    }
+                    is NotionDatabaseProperty.Select -> when (params.tagPropertyMappingType) {
+                        ProjectPropertyType.Id -> setOf(property.id)
+                        ProjectPropertyType.Name -> property.selected?.name?.let(::setOf)
+                        ProjectPropertyType.Email -> null
+                    }
+                    is NotionDatabaseProperty.MultiSelect -> when (params.tagPropertyMappingType) {
+                        ProjectPropertyType.Id -> property.selected.map(NotionDatabaseProperty.Select.Option::id)
+                        ProjectPropertyType.Name -> property.selected.map(NotionDatabaseProperty.Select.Option::name)
+                        ProjectPropertyType.Email -> null
+                    }?.toSet()?.takeIf(Set<String>::isNotEmpty)
+                    else -> null
+                } ?: emptySet()
+
+                card.id to tags
+            }
+        )
+    }
+
+    private fun NotionDatabaseProperty.getTextValue(type: ProjectPropertyType): String? =
+        when (this) {
+            is NotionDatabaseProperty.Title -> text
+            is NotionDatabaseProperty.Text -> text
+            is NotionDatabaseProperty.Select -> when (type) {
+                ProjectPropertyType.Id -> selected?.id
+                ProjectPropertyType.Name -> selected?.name
+                ProjectPropertyType.Email -> null
+            }
+            is NotionDatabaseProperty.MultiSelect -> selected.firstOrNull()?.let { option ->
+                when (type) {
+                    ProjectPropertyType.Id -> option.id
+                    ProjectPropertyType.Name -> option.name
+                    ProjectPropertyType.Email -> null
+                }
+            }
+            is NotionDatabaseProperty.Email -> email
+            is NotionDatabaseProperty.PhoneNumber -> phoneNumber
+            is NotionDatabaseProperty.People -> people.firstOrNull()?.getTextValue(type)
+            is NotionDatabaseProperty.CreatedBy -> createdBy.getTextValue(type)
+            is NotionDatabaseProperty.LastEditedBy -> lastEditedBy.getTextValue(type)
+            else -> null
+        }
+
+    private fun NotionDatabaseProperty.People.Person.getTextValue(type: ProjectPropertyType): String? =
+        when (this) {
+            is NotionDatabaseProperty.People.Person.User -> when (type) {
+                ProjectPropertyType.Id -> id
+                ProjectPropertyType.Name -> name
+                ProjectPropertyType.Email -> email
+            }
+            is NotionDatabaseProperty.People.Person.Bot -> when (type) {
+                ProjectPropertyType.Id -> id
+                ProjectPropertyType.Name -> name
+                ProjectPropertyType.Email -> null
+            }
+        }
+
+    private fun NotionDatabaseRow.getTitle(): String? {
+        val titleText = findProperty(ExternalProjectProperty.Id(CARD_TITLE_PROPERTY_ID))
+            ?.let { property -> property.value as? NotionDatabaseProperty.Title }
+            ?.text
+
+        val titleEmoji = (icon as? NotionIcon.Emoji)?.emoji?.let { emoji -> "$emoji " }.orEmpty()
+
+        return titleText?.let { "$titleEmoji$titleText" }
+    }
+
+    private fun NotionDatabaseRow.findProperty(property: ExternalProjectProperty): NotionDatabaseColumn? =
+        columns.firstNotNullOfOrNull { (key, column) ->
+            column.takeIf {
+                when (property) {
+                    is ExternalProjectProperty.Id -> column.value.id == property.id
+                    is ExternalProjectProperty.Name -> key == property.name
+                }
+            }
+        }
+
+    private suspend fun getAllNotionCards(databaseId: String, query: String): List<NotionDatabaseRow> {
+        return if (query.isEmpty()) {
+            var lastResponse = notion.queryDatabase(databaseId)
+            val result = lastResponse.results.toMutableList()
+
+            while (lastResponse.hasMore && lastResponse.nextCursor != null) {
+                lastResponse = notion.queryDatabase(databaseId, lastResponse.nextCursor)
+                result += lastResponse.results
+            }
+
+            result
+        } else {
+            notion.queryDatabase(databaseId, query).results
+        }
+    }
+
+    private suspend fun NotionDatabaseRow.getDescriptionAsMarkdown(): String =
+        markdownExporter.exportRecursively(getAllBlocks(), notion = notion, depthLevel = 2)
+
+    private suspend fun NotionDatabaseRow.getAllBlocks(): List<NotionBlock> {
+        var lastResponse = notion.retrieveBlockChildren(id)
+        val result = lastResponse.results.toMutableList()
+
+        while (lastResponse.hasMore && lastResponse.nextCursor != null) {
+            lastResponse = notion.retrieveBlockChildren(id, lastResponse.nextCursor)
+            result += lastResponse.results
+        }
+
+        return result
+    }
+
+    private fun createHttpClient(): HttpClient =
+        HttpClient(Apache) {
+            engine {
+                followRedirects = true
+                socketTimeout = 60_000
+                connectTimeout = 60_000
+                connectionRequestTimeout = 60_000
+            }
+        }
+
+    companion object {
+        private const val CARD_TITLE_PROPERTY_ID = "title"
+    }
+}

--- a/src/main/kotlin/space/SpaceBoardIdentifier.kt
+++ b/src/main/kotlin/space/SpaceBoardIdentifier.kt
@@ -1,0 +1,6 @@
+package com.jetbrains.space.import.space
+
+sealed interface SpaceBoardCustomIdentifier {
+    class Id(val id: String) : SpaceBoardCustomIdentifier
+    class Name(val name: String) : SpaceBoardCustomIdentifier
+}

--- a/src/main/kotlin/space/SpaceUploader.kt
+++ b/src/main/kotlin/space/SpaceUploader.kt
@@ -1,11 +1,16 @@
 package com.jetbrains.space.import.space
 
+import com.jetbrains.space.import.common.ImportSource
+import com.jetbrains.space.import.common.ProjectPropertyType
+import com.xenomachina.argparser.SystemExitException
 import io.ktor.client.*
 import io.ktor.client.engine.apache.*
 import io.ktor.client.features.logging.*
 import io.ktor.util.*
 import org.slf4j.LoggerFactory
+import space.jetbrains.api.runtime.BatchInfo
 import space.jetbrains.api.runtime.SpaceHttpClient
+import space.jetbrains.api.runtime.SpaceHttpClientWithCallContext
 import space.jetbrains.api.runtime.resources.projects
 import space.jetbrains.api.runtime.types.*
 import space.jetbrains.api.runtime.withPermanentToken
@@ -21,14 +26,17 @@ class SpaceUploader {
         token: String,
         issues: List<ExternalIssue>,
         projectIdentifier: ProjectIdentifier,
-        importSource: String,
+        importSource: ImportSource,
         assigneeMissingPolicy: ImportMissingPolicy,
         statusMissingPolicy: ImportMissingPolicy,
         onExistsPolicy: ImportExistsPolicy,
         dryRun: Boolean,
         batchSize: Int,
         debug: Boolean,
-    ) {
+        boardIdentifier: SpaceBoardCustomIdentifier?,
+        tags: Map<String, Set<String>>,
+        tagPropertyMappingType: ProjectPropertyType,
+    ): List<IssueImportResult> {
         val httpClient = createHttpClient()
             .let {
                 if (debug) {
@@ -47,18 +55,112 @@ class SpaceUploader {
 
         if (dryRun) logger.info("[DRY RUN]")
 
-        issues.chunked(batchSize).forEach { issuesBatched ->
-            val response = spaceClient.projects.planning.issues.importIssues(
+        val result = issues.chunked(batchSize).map { issuesBatched ->
+            spaceClient.projects.planning.issues.importIssues(
                 project = projectIdentifier,
-                metadata = ImportMetadata(importSource),
+                metadata = ImportMetadata(importSource.name),
                 issues = issuesBatched,
                 assigneeMissingPolicy = assigneeMissingPolicy,
                 statusMissingPolicy = statusMissingPolicy,
                 onExistsPolicy = onExistsPolicy,
                 dryRun = dryRun
-            )
-            logger.info(response.message)
+            ).also { response -> logger.info(response.message) }
         }
+
+        if (!dryRun) {
+            boardIdentifier?.let { spaceClient.addToBoard(projectIdentifier, boardIdentifier, result) }
+            spaceClient.addTags(projectIdentifier, tags, tagPropertyMappingType, result)
+        }
+
+        return result
+    }
+
+    private suspend fun SpaceHttpClientWithCallContext.addToBoard(
+        projectIdentifier: ProjectIdentifier,
+        boardIdentifier: SpaceBoardCustomIdentifier,
+        results: List<IssueImportResult>,
+    ) {
+        val boardId = when (boardIdentifier) {
+            is SpaceBoardCustomIdentifier.Id -> boardIdentifier.id
+            is SpaceBoardCustomIdentifier.Name -> getAllBoards(projectIdentifier).find { it.name == boardIdentifier.name }?.id
+        } ?: return logger.error("no board with the name provided found, skipping")
+
+        val issues = results.map { result ->
+            ((result.created ?: emptyList()) + (result.updated ?: emptyList()))
+                .mapNotNull(IssueImportResultItem::issue)
+        }.flatten()
+
+        issues.forEach { issue ->
+            projects.planning.boards.issues.addIssueToBoard(IssueIdentifier.Id(issue.id), BoardIdentifier.Id(boardId))
+        }
+    }
+
+    private suspend fun SpaceHttpClientWithCallContext.addTags(
+        projectIdentifier: ProjectIdentifier,
+        tags: Map<String, Set<String>>,
+        tagPropertyMappingType: ProjectPropertyType,
+        results: List<IssueImportResult>,
+    ) {
+        val preprocessedTags: Map<String, Set<String>> = when (tagPropertyMappingType) {
+            ProjectPropertyType.Id -> tags
+            ProjectPropertyType.Name -> {
+                val allHierarchicalTagsMap = getAllHierarchicalTags(projectIdentifier)
+                    .associate { tag -> tag.name to tag.id }
+
+                tags.mapValues { (_, tags) ->
+                    tags.mapNotNullTo(HashSet()) { tag -> allHierarchicalTagsMap[tag] }
+                }
+            }
+            ProjectPropertyType.Email -> throw SystemExitException("can't map tags' emails", 2)
+        }
+
+        for (result in results) {
+            val items = ((result.created ?: emptyList()) + (result.updated ?: emptyList()))
+                .filterNot { it.issue == null }
+
+            for (item in items) {
+                val tagIds = item.externalId?.let(preprocessedTags::get)?.takeIf(Set<String>::isNotEmpty)
+                    ?: continue
+
+                for (tagId in tagIds) {
+                    projects.planning.issues.tags.addIssueTag(
+                        project = projectIdentifier,
+                        issueId = IssueIdentifier.Id(item.issue!!.id),
+                        tagId = tagId,
+                    )
+                }
+            }
+        }
+    }
+
+    private suspend fun SpaceHttpClientWithCallContext.getAllBoards(projectIdentifier: ProjectIdentifier): List<BoardRecord> {
+        var lastResponse = projects.planning.boards.getAllBoards(projectIdentifier)
+        val result: MutableList<BoardRecord> = mutableListOf()
+
+        while (lastResponse.data.isNotEmpty()) {
+            result += lastResponse.data
+            lastResponse = projects.planning.boards.getAllBoards(
+                project = projectIdentifier,
+                batchInfo = BatchInfo(lastResponse.next, 100)
+            )
+        }
+
+        return result
+    }
+
+    private suspend fun SpaceHttpClientWithCallContext.getAllHierarchicalTags(projectIdentifier: ProjectIdentifier): List<PlanningTag> {
+        var lastResponse = projects.planning.tags.getAllHierarchicalTags(projectIdentifier)
+        val result: MutableList<PlanningTag> = mutableListOf()
+
+        while (lastResponse.data.isNotEmpty()) {
+            result += lastResponse.data
+            lastResponse = projects.planning.tags.getAllHierarchicalTags(
+                project = projectIdentifier,
+                batchInfo = BatchInfo(lastResponse.next, 100)
+            )
+        }
+
+        return result
     }
 
     private fun createHttpClient(): HttpClient {

--- a/src/main/kotlin/youtrack/YoutrackIssuesLoader.kt
+++ b/src/main/kotlin/youtrack/YoutrackIssuesLoader.kt
@@ -20,15 +20,15 @@ class YoutrackIssuesLoader(private val serverUrl: String, private val token: Str
         private val logger = LoggerFactory.getLogger(YoutrackIssuesLoader::class.java)
     }
 
-    override suspend fun load(query: String) : IssuesLoadResult {
+    override suspend fun load(params: IssuesLoader.Params) : IssuesLoadResult {
         return try {
             val url = URL(serverUrl).toString().trimEnd('/')
             val youtrack = with(YouTrack) {
                 if (token.isNullOrBlank()) authorizeAsGuest(url) else authorizeByPermanentToken(url, token)
             }
 
-            val issuesCount = youtrack.issues(query).count()
-            val issues = youtrack.issues(query).mapIndexedNotNull { issueIndex, it ->
+            val issuesCount = youtrack.issues(params.query).count()
+            val issues = youtrack.issues(params.query).mapIndexedNotNull { issueIndex, it ->
                 try {
                     val issue = ExternalIssue(
                         summary = it.summary,
@@ -59,7 +59,7 @@ class YoutrackIssuesLoader(private val serverUrl: String, private val token: Str
                 logger.error("some issues failed to parse, report the problem here: https://github.com/JetBrains/space-issues-import/issues/new")
             }
 
-            IssuesLoadResult.Success(issues)
+            IssuesLoadResult.Success(issues, emptyMap())
         } catch (e: YouTrackClientException) {
             logger.error("failed to parse YT response. Does `--youtrackServer` URL match the one in your YT Domain Settings? Typically, it should end with /youtrack")
             logger.error("original error message: $e")


### PR DESCRIPTION
Already tested on the project with quite many tasks, worked as expected 😄

### Preamble
- [x] I had to bump some dependencies including the Space SDK version to make the build work ¯\\_(ツ)_/¯ 
- [x] I changed some existing logic contracts (e.g. the loader) but without actually changing the logic
- [ ] I did not refactor anything, so the updated codebase might be improved
- [ ] Unfortunately, I couldn't properly export the `--help` as the output is messed up (3 characters per column) and I'm too lazy to do it manually

# The new functionality
- [x] Add issues to a board (makes a lot of requests, as the Import endpoint does not support it)
- [x] Add tags to the issues (makes a lot of requests as well, applied only to Notion)

# Notion
- [x] Uses my own SDK to interact with their API
- [x] The project approach is a bit different so we need to provide some additional info, e.g. which property of the ticket is actually a Status or the Assignee
- [x] Custom query, properties mapping (including different types — using ID or Name) 